### PR TITLE
Update popup.js

### DIFF
--- a/app/popup.js
+++ b/app/popup.js
@@ -140,6 +140,8 @@ document.addEventListener('DOMContentLoaded', function() {
       run_script(url, 'fivethirtyeight.js');
     } else if (url.startsWith('http://giphy.com')) {
       run_script(url, 'giphy.js');
+    } else if (url.startsWith('https://giphy.com')) {
+      run_script(url, 'giphy.js');  
     } else {
       // Shorten
       finish(shrtn(url));


### PR DESCRIPTION
This (might) fix the problem with https links in giphy.
